### PR TITLE
Fix multiselect issue

### DIFF
--- a/templates/bootstrap/layout/checkboxselectmultiple.html
+++ b/templates/bootstrap/layout/checkboxselectmultiple.html
@@ -6,8 +6,8 @@
   <div class="multiselect">
     {% for choice in field.field.choices %}
       <div class="checkbox-field multiselect-option">
-        <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
-        <label class="checkbox{% if inline_class %} {{ inline_class }}{% endif %}" for="id_{{ field.id_for_label }}_{{ forloop.counter }}">
+        <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+        <label class="checkbox{% if inline_class %} {{ inline_class }}{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
           <div class="checkbox-status">
             <svg class="icon">
               <use xlink:href="#tried"></use>


### PR DESCRIPTION
For this card  https://favro.com/organization/b03d6d6d9b11b61167ac4246/418c53a770389640d415a230?card=Dev-16119 

The problem: When selecting an option in the "make this resource public section" it was actually deselecting an option in the "categories" section and scrolling back up to this section. This was due to the inputs sharing id's. e.g the Analytics and testing id was "id_1" and the ID for the first group in the lower section was also "id_1". 

I have removed an undefined reference and replaced it with the name of the section to ensure that the id's are more specific and not duplicated across sections. 

To test:  
Log in and go to your user name in http://127.0.0.1:8000/admin/accounts/user/ 
Add some approved organisations (can just add all)
Fill in the form ensuring that you deselect "make this resource public?"
When the group selection appears below ensure that you can select groups without this affecting the categories and scrolling up. 
Submit the resource
Go to http://127.0.0.1:8000/admin/resources/resource/ and check that the resource appears and that the categories and publicity groups match the ones you have selected. 



