### PR TITLE
Different resource count for public and logged in

### DIFF
--- a/apps/resources/templatetags/resource_count.py
+++ b/apps/resources/templatetags/resource_count.py
@@ -1,0 +1,13 @@
+from django.template import Library
+from django.template.defaulttags import cycle as cycle_original
+
+register = Library()
+
+
+@register.assignment_tag
+def resource_count(resource_category, user):
+    '''
+    Provide a count of available resources for a category depending on
+    the user
+    '''
+    return resource_category.get_resource_count(user)

--- a/apps/resources/templatetags/resource_count.py
+++ b/apps/resources/templatetags/resource_count.py
@@ -1,5 +1,4 @@
 from django.template import Library
-from django.template.defaulttags import cycle as cycle_original
 
 register = Library()
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ raven==6.10.0
 django-admin-sortable==2.1.18
 
 # Masked database backups
-django-maskpostgresdata==0.1.8
+django-maskpostgresdata==0.1.11
 
 # Storage
 django-storages==1.7.1

--- a/templates/resources/resourcecategory_list.html
+++ b/templates/resources/resourcecategory_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load thumbnail staticfiles %}
+{% load thumbnail staticfiles resource_count %}
 
 
 {% block main_content %}
@@ -18,7 +18,8 @@
                 <div class="category-grid__item-detail">
                   <a href="#" class="category_toggle" data-target="{{ category.pk }}">
                     <h3>{{ category.title }}</h3>
-                    <p>{{ category.get_resource_count }} resource{{ category.get_resource_count|pluralize }}</p>
+                    {% resource_count category request.user as resource_count %}
+                    <p>{{ resource_count }} resource{{ resource_count|pluralize }}</p>
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
**Sources**
https://app.forecast.it/project/P-17/workflow/T770

**Description**
Pass the request user to the method which calculates the number of resources so we can show logged in users the actual count for them (was previously showing all users the public count which can be lower).

This also includes some stuff that was on master but isn't on dev.

**How to test**
Go here as a logged out user: http://127.0.0.1:8000/explore/. Login then go back to that page. You should see the count of each resource increase.