### PR TITLE
handle multiple matching org domains

### DIFF
--- a/apps/accounts/tests/test_forms.py
+++ b/apps/accounts/tests/test_forms.py
@@ -28,6 +28,42 @@ class UserRegistrationFormTest(TestCase):
         user = form.save()
         self.assertEqual(user.approved_organisations.first().id, self.organisation.id)
 
+    def test_permissions_multiple_grants(self):
+        """Test orgs are approved if there are multiple matches to the email domain."""
+
+        organisation_a = OrganisationFactory.create(email="test_org_a@test.com")
+        organisation_b = OrganisationFactory.create(email="test_org_b@test.com")
+        organisation_c = OrganisationFactory.create(email="test_org_c@something.com")
+
+        form = UserRegistrationForm({
+            'email': 'test@test.com',
+            'password': 'test123',
+            'confirm_password': 'test123',
+            'first_name': 'test',
+            'last_name': 'test',
+            'chosen_organisations': [organisation_a, organisation_b],
+            'privacy_agreement': True,
+        })
+        self.assertTrue(form.is_valid())
+        user = form.save()
+        self.assertIn(organisation_a, user.approved_organisations.all())
+        self.assertIn(organisation_b, user.approved_organisations.all())
+        self.assertNotIn(organisation_c, user.approved_organisations.all())
+
+    def test_permissions_no_org(self):
+        form = UserRegistrationForm({
+            'email': 'test@nomatchingdomain.com',
+            'password': 'test123',
+            'confirm_password': 'test123',
+            'first_name': 'test',
+            'last_name': 'test',
+            'chosen_organisations': [self.organisation],
+            'privacy_agreement': True,
+        })
+        self.assertTrue(form.is_valid())
+        user = form.save()
+        self.assertEqual(user.approved_organisations.all().count(), 0)
+
     def test_permissions_no_grant(self):
         """
         Test grant permission to make sure user get's active if email domain matches organisation.


### PR DESCRIPTION
Sources
Closes COMMONSLIBRARY-C
https://app.forecast.it/project/P-17/workflow/T1223
https://sentry.io/organizations/devsoc/issues/1601421801/?project=298538

Description
If there are multiple orgs matched to the user's email domain, add each one to the user's `approved_organisations`. 

Setup instructions
- `make reset`

How to test
- Try and register with demo@the-open.net should now no longer cause a 500 and if you select multiple orgs (that share the same domain as the email) you should have them all added to the `approved_organisations`.
