### PR TITLE
Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   test:
     name: Test -- tox
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Setup Node.js

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ install-local: npm-install pip-install-local
 
 # Pip
 pip-install-local: venv-check
+	pip install setuptools==59.8.0
 	pip install -r requirements/local.txt
 
 

--- a/apps/resources/models.py
+++ b/apps/resources/models.py
@@ -143,7 +143,7 @@ class Resource(models.Model):
             results[resource_id] = len(matches)
 
         resources_ids = sorted(results, key=results.get, reverse=True)[:limit]
-        preserved = Case(* [When(pk=pk, then=pos) for pos, pk in enumerate(resources_ids)])
+        preserved = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(resources_ids)])
         resources = Resource.objects.filter(id__in=resources_ids).order_by(preserved)
         return resources
 

--- a/bin/pip_install.sh
+++ b/bin/pip_install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+python -m pip install setuptools==59.8.0
+exec python -m pip install "$@"

--- a/fabfile.py
+++ b/fabfile.py
@@ -109,6 +109,7 @@ def update():
         run('git pull')
 
         # Install python packages
+        run('pip install --quiet setuptools==59.8.0')
         run('pip install --quiet --requirement requirements/production.txt')
 
         # Install nvm using .nvmrc version

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ Django==1.11.28
 Pillow==4.3.0
 dj-database-url==0.5.0
 olefile==0.45.1
-psycopg2==2.7.3.2
+psycopg2==2.7.7
 pytz==2019.2
 raven==6.10.0
 django-admin-sortable==2.1.18

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = check, lint, tests
 skipsdist = true
 
 [testenv]
-basepython = python3.6
-envdir = {toxworkdir}/py36
+basepython = python3.7
+envdir = {toxworkdir}/py37
 deps =
     -rrequirements/base.txt
     -rrequirements/testing.txt

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 basepython = python3.7
 envdir = {toxworkdir}/py37
+install_command = {toxinidir}/bin/pip_install.sh {opts} {packages}
 deps =
     -rrequirements/base.txt
     -rrequirements/testing.txt


### PR DESCRIPTION
Python 3.6 won't be as easy to install on Ubuntu 22.04 - so the plan is to upgrade a few which can be upgraded (as Django 1.11 supports Python 3.7) to keep support for longer.

Slight downside - psycopg2 2.7 is now a pain to install (see https://github.com/developersociety/syriacivildefence/pull/76), so needs workarounds to build.