### PR TITLE
Updated resources pagination to show 10 resources per page

### DIFF
--- a/apps/api/v1/paginations.py
+++ b/apps/api/v1/paginations.py
@@ -2,6 +2,6 @@ from rest_framework.pagination import PageNumberPagination
 
 
 class ResourcesPagination(PageNumberPagination):
-    page_size = 20
+    page_size = 10
     page_size_query_param = 'page_size'
     max_page_size = 1000


### PR DESCRIPTION
# Sources
https://trello.com/c/3EuzoEnO/25-4-is-it-possible-to-show-like-8-resources-on-the-frontend-it-looks-overwhelming-and-cluttered-with-so-many

# Description
This PR reduces the number of resources shown on a page from 20 down to 10. 

# Setup instructions
You may need to run `./manage.py migrate` due to previous changes.

# How to test
Go to http://127.0.0.1:8000/ and http://127.0.0.1:8000/search/ and check that only 10 resources are displaying. 

(While the card mentions 8 resources due to the styling of the tile sizes either 5 or 10 seemed like the best option for keeping the site looking nice. As the partner has said they're happy for me to take initiative on making the change as I see fit I've gone for what seemed like the best option. Please let me know if you have other suggestions)

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-f804361f9b6b4859bdcd69d7704168e5.

# Pre-review checklist
- [ ] PR Tags & Milestones?
- [ ] Are any general setup instructions added to the README?
- [ ] Have you updated the docs/changelog.md (if required)?
- [ ] Have you updated the docs/features.md (if required)?

