### PR TITLE
Change ResourceFilter for tags

### DIFF
--- a/apps/api/v1/filters.py
+++ b/apps/api/v1/filters.py
@@ -4,6 +4,7 @@ from django_filters.rest_framework import FilterSet
 from accounts.models import User
 from directory.models import Organisation
 from resources.models import Resource
+from tags.models import Tag
 
 
 class ResourceFilter(FilterSet):
@@ -29,7 +30,11 @@ class ResourceFilter(FilterSet):
             'most_tried': 'Most tried',
         }
     )
+    tags = django_filters.filters.ModelMultipleChoiceFilter(
+        queryset=Tag.objects.all(),
+        conjoined=True,
+    )
 
     class Meta:
         model = Resource
-        fields = ('tags', 'categories', 'organisation', 'created_by')
+        fields = ('categories', 'organisation', 'created_by')

--- a/apps/api/v1/tests/test_views.py
+++ b/apps/api/v1/tests/test_views.py
@@ -15,7 +15,8 @@ class ResourceTests(APITestCase):
     def setUp(self):
         self.url = reverse('resource-list')
 
-        self.resource_1 = ResourceFactory.create(status=RESOURCE_APPROVED)
+        self.test_tag = TagFactory(title='test')
+        self.resource_1 = ResourceFactory.create(status=RESOURCE_APPROVED, tags=[self.test_tag])
         self.like_url = reverse('resource-like', kwargs={'pk': self.resource_1.id})
         self.tried_url = reverse('resource-tried', kwargs={'pk': self.resource_1.id})
 
@@ -65,6 +66,21 @@ class ResourceTests(APITestCase):
         response = self.logged_in_client.put(self.tried_url, format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertFalse(self.user in self.resource_1.tried.all())
+
+    def test_single_tags(self):
+        test2_tag = TagFactory(title='test2')
+        ResourceFactory.create(status=RESOURCE_APPROVED, tags=[test2_tag])
+        url = f'{self.url}?tags={self.test_tag.id}'
+        response = self.client.get(url)
+        self.assertEqual(response.json()['count'], 1)
+
+    def test_multi_tags(self):
+        test2_tag = TagFactory(title='test2')
+        ResourceFactory.create(status=RESOURCE_APPROVED, tags=[test2_tag])
+        ResourceFactory.create(status=RESOURCE_APPROVED, tags=[test2_tag, self.test_tag])
+        url = f'{self.url}?tags={self.test_tag.id}&tags={test2_tag.id}'
+        response = self.client.get(url)
+        self.assertEqual(response.json()['count'], 1)
 
 
 class OrganisationTests(APITestCase):


### PR DESCRIPTION
# Sources
https://trello.com/c/Pz2fCEtv/18-be-tags-filtering-to-be-and-not-or-preferably-scoring-not-exclusively-and-so-abc-would-find-abc-ab-ac-b-c-a

# Description
- Change tag filtering to be AND

# Setup instructions
`fab get_backup`

# How to test
1. Go to http://127.0.0.1:8000/api/v1/resources/?tags=61 and check the `count`. Now go to http://127.0.0.1:8000/api/v1/resources/?tags=61&tags=543 and check if tags filter with AND
